### PR TITLE
Add word cloud panel and generation API

### DIFF
--- a/create_table.sql
+++ b/create_table.sql
@@ -7,3 +7,9 @@ CREATE TABLE IF NOT EXISTS messages (
     text TEXT,
     UNIQUE (msg_date, sender, text)
 );
+
+CREATE TABLE IF NOT EXISTS wordclouds (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    image TEXT
+);

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ uvicorn
 boto3
 psycopg2-binary
 python-multipart
+wordcloud
+Pillow
+numpy

--- a/static/index.html
+++ b/static/index.html
@@ -16,6 +16,22 @@
       border-collapse: collapse;
       padding: 4px;
     }
+
+    body {
+      margin-right: 220px;
+    }
+
+    #side-panel {
+      position: fixed;
+      top: 0;
+      right: 0;
+      width: 200px;
+      height: 100%;
+      overflow-y: auto;
+      border-left: 1px solid #ccc;
+      background: #f9f9f9;
+      padding: 10px;
+    }
   </style>
 </head>
 
@@ -25,6 +41,11 @@
   <input id="query" placeholder="Search text" />
   <button onclick="doSearch()">Search</button>
   <table id="results"></table>
+  <div id="side-panel">
+    <h3>Word Cloud</h3>
+    <img id="wordcloud-image" style="max-width: 100%;" />
+    <p><a href="#" id="generate-wordcloud">Generate Word Cloud</a></p>
+  </div>
   <script>
     async function doSearch() {
       const query = document.getElementById('query').value;
@@ -60,9 +81,25 @@
           }
           tr.appendChild(td);
         });
-        table.appendChild(tr);
-      });
+      table.appendChild(tr);
+    });
+  }
+
+  async function loadWordCloud() {
+    const res = await fetch('/wordcloud');
+    const data = await res.json();
+    if (data.image) {
+      document.getElementById('wordcloud-image').src = 'data:image/png;base64,' + data.image;
     }
+  }
+
+  document.getElementById('generate-wordcloud').addEventListener('click', async (e) => {
+    e.preventDefault();
+    await fetch('/generate_wordcloud', { method: 'POST' });
+    loadWordCloud();
+  });
+
+  loadWordCloud();
   </script>
 </body>
 


### PR DESCRIPTION
## Summary
- create `wordclouds` table
- generate & store word clouds via new `/generate_wordcloud` API
- fetch saved image with `/wordcloud`
- display fixed right-side panel with word cloud
- include word cloud libraries in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687b3ef174b88330b31702bdb377d250