### PR TITLE
Limit displayed word cloud to top 100 words

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,6 @@ app.add_middleware(
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 
-
 def get_conn():
     cfg = settings.database
     return psycopg2.connect(
@@ -172,7 +171,7 @@ def get_wordcloud():
     if row:
         data = row[0]
         if isinstance(data, dict):
-            items = sorted(data.items(), key=lambda x: x[1], reverse=True)[:100]
+            items = sorted(data.items(), key=lambda x: x[1], reverse=True)[:200]
             data = {k: v for k, v in items}
         return {"words": data}
     return {"words": None}

--- a/main.py
+++ b/main.py
@@ -170,7 +170,11 @@ def get_wordcloud():
     cur.close()
     conn.close()
     if row:
-        return {"words": row[0]}
+        data = row[0]
+        if isinstance(data, dict):
+            items = sorted(data.items(), key=lambda x: x[1], reverse=True)[:100]
+            data = {k: v for k, v in items}
+        return {"words": data}
     return {"words": None}
 
 


### PR DESCRIPTION
## Summary
- limit the word cloud output to the 100 most common words

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687df657aafc83309cc48572c5cc9adc