### PR TITLE
Style conversation messages by sender

### DIFF
--- a/static/conversations.css
+++ b/static/conversations.css
@@ -21,6 +21,11 @@ body {
   background: #fff;
 }
 
+#message-container {
+  display: flex;
+  flex-direction: column;
+}
+
 .conversation {
   cursor: pointer;
   margin-bottom: 8px;
@@ -42,17 +47,33 @@ body {
 }
 
 .message {
+  display: flex;
   margin-bottom: 8px;
-  padding: 6px;
-  border-radius: 4px;
 }
 
-.message.chris {
-  background: #e3f2fd;
+.message .text {
+  padding: 6px 10px;
+  border-radius: 12px;
+  color: #fff;
+  max-width: 70%;
 }
 
 .message.hayley {
-  background: #fce4ec;
+  justify-content: flex-start;
+}
+
+.message.hayley .text {
+  background: #6c757d;
+  text-align: left;
+}
+
+.message.chris {
+  justify-content: flex-end;
+}
+
+.message.chris .text {
+  background: #0b93f6;
+  text-align: right;
 }
 
 #loading {

--- a/static/conversations.html
+++ b/static/conversations.html
@@ -53,12 +53,14 @@
       const data = await res.json();
       loading.style.display = 'none';
       data.messages.forEach(m => {
-        const div = document.createElement('div');
-        div.className = 'message';
-        div.classList.add(m.sender.toLowerCase());
-        const date = new Date(m.msg_date).toLocaleString();
-        div.textContent = `[${date}] ${m.sender}: ${m.text}`;
-        container.appendChild(div);
+        const wrapper = document.createElement('div');
+        wrapper.className = 'message';
+        wrapper.classList.add(m.sender.toLowerCase());
+        const textDiv = document.createElement('div');
+        textDiv.className = 'text';
+        textDiv.textContent = m.text;
+        wrapper.appendChild(textDiv);
+        container.appendChild(wrapper);
       });
     }
 


### PR DESCRIPTION
## Summary
- display conversation texts in left/right chat bubbles
- color Chris' messages blue and Hayley's gray with white text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a109eed7008330ad0812c66638275c