### PR TITLE
Add monthly message analytics page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -12,7 +12,7 @@
 
 <body>
   <h1>CSV Search</h1>
-  <p><a href="/upload">Upload CSV</a> | <a href="/conversations">Conversations</a></p>
+  <p><a href="/upload">Upload CSV</a> | <a href="/conversations">Conversations</a> | <a href="/monthly">Messages Per Month</a></p>
   <div id="search-controls">
     <div id="search-terms">
       <input class="term" placeholder="Search text" list="tag-suggestions" />

--- a/static/monthly.html
+++ b/static/monthly.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Messages Per Month</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/static/styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <h1>Messages Per Month</h1>
+  <canvas id="chart" width="800" height="400"></canvas>
+  <script>
+    async function loadData() {
+      const res = await fetch('/api/messages_per_month');
+      const data = await res.json();
+      const labels = data.months.map(m => m.month);
+      const chris = data.months.map(m => m.Chris);
+      const hayley = data.months.map(m => m.Hayley);
+      const ctx = document.getElementById('chart').getContext('2d');
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [
+            {
+              label: 'Hayley',
+              data: hayley,
+              backgroundColor: 'rgba(255, 99, 132, 0.5)'
+            },
+            {
+              label: 'Chris',
+              data: chris,
+              backgroundColor: 'rgba(54, 162, 235, 0.5)'
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          scales: {
+            y: {
+              beginAtZero: true
+            }
+          }
+        }
+      });
+    }
+    loadData();
+  </script>
+</body>
+</html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -108,6 +108,7 @@ def test_index_upload_and_conversations_pages(client):
     assert "<html" in main.index()
     assert "<html" in main.upload_page()
     assert "<html" in main.conversations_page()
+    assert "<html" in main.monthly_page()
 
 
 def test_upload(monkeypatch, client):
@@ -158,6 +159,24 @@ def test_message_context(monkeypatch):
     conn2 = DummyConn(cursor2)
     monkeypatch.setattr(main, "get_conn", lambda: conn2)
     assert main.message_context(3) == {"groups": []}
+
+
+def test_messages_per_month(monkeypatch):
+    rows = [
+        ("2023-01", "Chris", 2),
+        ("2023-01", "Hayley", 1),
+        ("2023-02", "Chris", 3),
+    ]
+    cursor = SeqCursor([rows])
+    conn = DummyConn(cursor)
+    monkeypatch.setattr(main, "get_conn", lambda: conn)
+    res = main.messages_per_month()
+    assert res == {
+        "months": [
+            {"month": "2023-01", "Chris": 2, "Hayley": 1},
+            {"month": "2023-02", "Chris": 3, "Hayley": 0},
+        ]
+    }
 
 
 def test_add_and_list_tags(monkeypatch):


### PR DESCRIPTION
## Summary
- add API to aggregate message counts per month for Chris and Hayley
- create `/monthly` page with bar chart of monthly message totals
- link new page from index and add tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1252905b88330a4274437652a5087