### PR TITLE
Fetch next/previous messages by date

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -187,6 +187,8 @@
           const tr = createRow(row, group.match_indices.includes(i));
           tbody.appendChild(tr);
         });
+        group.start_date = group.rows[0].Date;
+        group.end_date = group.rows[group.rows.length - 1].Date;
         const bottomRow = document.createElement('tr');
         const bottomTd = document.createElement('td');
         bottomTd.colSpan = 2;
@@ -240,14 +242,16 @@
 
     async function loadMore(idx, delta) {
       const group = currentGroups[idx];
-      let startId;
+      let startDate;
+      let direction;
       if (delta < 0) {
-        startId = group.start + 1 + delta;
-        if (startId < 1) startId = 1;
+        startDate = group.start_date;
+        direction = 'prev';
       } else {
-        startId = group.end + 2;
+        startDate = group.end_date;
+        direction = 'next';
       }
-      const res = await fetch(`/messages?start=${startId}&count=${Math.abs(delta)}`);
+      const res = await fetch(`/messages?start=${encodeURIComponent(startDate)}&count=${Math.abs(delta)}&direction=${direction}`);
       const data = await res.json();
       if (!data.rows.length) return;
       const tbody = document.querySelector(`tbody[data-group="${idx}"]`);
@@ -257,14 +261,14 @@
           const tr = createRow(row);
           tbody.insertBefore(tr, reference);
         });
-        group.start -= data.rows.length;
+        group.start_date = data.rows[0].Date;
       } else {
         const reference = tbody.lastElementChild;
         data.rows.forEach((row) => {
           const tr = createRow(row);
           tbody.insertBefore(tr, reference);
         });
-        group.end += data.rows.length;
+        group.end_date = data.rows[data.rows.length - 1].Date;
       }
     }
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -83,11 +83,11 @@ def test_execute_search_groups(monkeypatch):
     cursor = SeqCursor([
         [{"id": 1}, {"id": 2}, {"id": 15}],
         [
-            {"id": 1, "msg_date": 1, "sender": "A", "phone": "p", "text": "t", "tags": []},
-            {"id": 2, "msg_date": 2, "sender": "A", "phone": "p", "text": "t2", "tags": []},
+            {"id": 1, "Date": 1, "sender": "A", "phone": "p", "text": "t", "tags": []},
+            {"id": 2, "Date": 2, "sender": "A", "phone": "p", "text": "t2", "tags": []},
         ],
         [
-            {"id": 15, "msg_date": 3, "sender": "B", "phone": "p", "text": "x", "tags": []}
+            {"id": 15, "Date": 3, "sender": "B", "phone": "p", "text": "x", "tags": []}
         ],
     ])
     conn = DummyConn(cursor)
@@ -145,7 +145,8 @@ def test_get_messages(monkeypatch):
     cursor = SeqCursor([rows])
     conn = DummyConn(cursor)
     monkeypatch.setattr(main, "get_conn", lambda: conn)
-    res = main.get_messages(1, 1)
+    now = datetime.now()
+    res = main.get_messages(now, 1)
     assert res["rows"] == rows
 
 


### PR DESCRIPTION
## Summary
- Load more messages based on surrounding timestamps instead of numeric IDs
- Track start and end dates of result groups to support date-based fetching
- Adjust tests for new date-based message retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a198b1dc0883309c416a4fe035db3e